### PR TITLE
Modal form

### DIFF
--- a/src/features/cabins/AddCabin.jsx
+++ b/src/features/cabins/AddCabin.jsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import Button from "../../ui/Button";
+import Modal from "../../ui/Modal";
+import CreateCabinForm from "./CreateCabinForm";
+
+function AddCabin() {
+  const [isOpenModal, setIsOpenModal] = useState();
+  return (
+    <div>
+      <Button onClick={() => setIsOpenModal((show) => !show)}>
+        Add New Cabin
+      </Button>
+      {isOpenModal && (
+        <Modal onClose={() => setIsOpenModal(false)}>
+          <CreateCabinForm onCloseModal={() => setIsOpenModal(false)} />
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export default AddCabin;

--- a/src/features/cabins/AddCabin.jsx
+++ b/src/features/cabins/AddCabin.jsx
@@ -6,7 +6,7 @@ import CabinTable from "./CabinTable";
 // Compound component to display from or table.
 function AddCabin() {
   return (
-    
+    <div>
       <Modal>
         <Modal.Open opens="cabin-form">
           <Button>Add new Cabin</Button>
@@ -15,14 +15,14 @@ function AddCabin() {
           <CreateCabinForm />
         </Modal.Window>
 
-        <Modal.Open opens="table">
+        {/* <Modal.Open opens="table">
         <Button>Show Table</Button>
         </Modal.Open>
         <Modal.Window name="table">
         <CabinTable />
-      </Modal.Window>
+      </Modal.Window> */}
       </Modal>
-
+    </div>
   );
 }
 // function AddCabin() {

--- a/src/features/cabins/AddCabin.jsx
+++ b/src/features/cabins/AddCabin.jsx
@@ -1,22 +1,44 @@
-import { useState } from "react";
 import Button from "../../ui/Button";
 import Modal from "../../ui/Modal";
 import CreateCabinForm from "./CreateCabinForm";
+import CabinTable from "./CabinTable";
 
+// Compound component to display from or table.
 function AddCabin() {
-  const [isOpenModal, setIsOpenModal] = useState();
   return (
-    <div>
-      <Button onClick={() => setIsOpenModal((show) => !show)}>
-        Add New Cabin
-      </Button>
-      {isOpenModal && (
-        <Modal onClose={() => setIsOpenModal(false)}>
-          <CreateCabinForm onCloseModal={() => setIsOpenModal(false)} />
-        </Modal>
-      )}
-    </div>
+    
+      <Modal>
+        <Modal.Open opens="cabin-form">
+          <Button>Add new Cabin</Button>
+        </Modal.Open>
+        <Modal.Window name="cabin-form">
+          <CreateCabinForm />
+        </Modal.Window>
+
+        <Modal.Open opens="table">
+        <Button>Show Table</Button>
+        </Modal.Open>
+        <Modal.Window name="table">
+        <CabinTable />
+      </Modal.Window>
+      </Modal>
+
   );
 }
+// function AddCabin() {
+//   const [isOpenModal, setIsOpenModal] = useState();
+//   return (
+//     <div>
+//       <Button onClick={() => setIsOpenModal((show) => !show)}>
+//         Add New Cabin
+//       </Button>
+//       {isOpenModal && (
+//         <Modal onClose={() => setIsOpenModal(false)}>
+//           <CreateCabinForm onCloseModal={() => setIsOpenModal(false)} />
+//         </Modal>
+//       )}
+//     </div>
+//   );
+// }
 
 export default AddCabin;

--- a/src/features/cabins/CabinRow.jsx
+++ b/src/features/cabins/CabinRow.jsx
@@ -1,9 +1,11 @@
 import styled from "styled-components";
-import { useState } from "react";
 
 import { HiTrash, HiPencil, HiSquare2Stack } from "react-icons/hi2";
 
 import CreateCabinForm from "./CreateCabinForm";
+import Modal from "../../ui/Modal";
+import ConfirmDelete from "../../ui/ConfirmDelete";
+
 import { useDeleteCabin } from "./useDeleteCabin";
 import { formatCurrency } from "../../utils/helpers";
 import { useCreateCabin } from "./useCreateCabin";
@@ -49,7 +51,7 @@ const Discount = styled.div`
 
 function CabinRow({ cabin }) {
   // console.log("Cabin prop:", cabin);
-  const [showForm, setShowForm] = useState(false);
+
   const { isDeleting, deleteCabin } = useDeleteCabin();
   const { isCreating, createCabin } = useCreateCabin();
 
@@ -75,32 +77,45 @@ function CabinRow({ cabin }) {
   }
 
   return (
-    <>
-      <TableRow role="row">
-        <Img src={image}></Img>
-        <Cabin>{name}</Cabin>
-        <div>Fits up to {maxCapacity}</div>
-        <Price>{formatCurrency(regularPrice)}</Price>
-        {discount ? (
-          <Discount>{formatCurrency(discount)}</Discount>
-        ) : (
-          <span>&mdash;</span>
-        )}
-        <div>
-          <button disabled={isCreating} onClick={handleDuplicate}>
-            <HiSquare2Stack />
-          </button>
-          <button onClick={() => setShowForm((show) => !show)}>
-            <HiPencil />
-          </button>
-          <button onClick={() => deleteCabin(cabinId)} disabled={isDeleting}>
-            <HiTrash />
-          </button>
-        </div>
-      </TableRow>
-      {showForm && <CreateCabinForm cabinToEdit={cabin} />}
-      {/* {console.log(cabin)} */}
-    </>
+    <TableRow role="row">
+      <Img src={image}></Img>
+      <Cabin>{name}</Cabin>
+      <div>Fits up to {maxCapacity}</div>
+      <Price>{formatCurrency(regularPrice)}</Price>
+      {discount ? (
+        <Discount>{formatCurrency(discount)}</Discount>
+      ) : (
+        <span>&mdash;</span>
+      )}
+      <div>
+        <button disabled={isCreating} onClick={handleDuplicate}>
+          <HiSquare2Stack />
+        </button>
+        <Modal>
+          <Modal.Open opens="edit">
+            <button>
+              <HiPencil />
+            </button>
+          </Modal.Open>
+          <Modal.Window name="edit">
+            <CreateCabinForm cabinToEdit={cabin} />
+          </Modal.Window>
+
+          <Modal.Open>
+            <button>
+              <HiTrash />
+            </button>
+          </Modal.Open>
+          <Modal.Window>
+            <ConfirmDelete
+              resourceName="cabins"
+              disabled={isDeleting}
+              onConfirm={() => deleteCabin(cabinId)}
+            />
+          </Modal.Window>
+        </Modal>
+      </div>
+    </TableRow>
   );
 }
 

--- a/src/features/cabins/CreateCabinForm.jsx
+++ b/src/features/cabins/CreateCabinForm.jsx
@@ -10,7 +10,7 @@ import FormRow from "../../ui/FormRow";
 import { useCreateCabin } from "./useCreateCabin";
 import { useEditCabin } from "./useEditCabin";
 
-function CreateCabinForm({ cabinToEdit = {} }) {
+function CreateCabinForm({ cabinToEdit = {}, onCloseModal }) {
   const { isCreating, createCabin } = useCreateCabin();
   const { isEditing, editCabin } = useEditCabin();
 
@@ -39,6 +39,7 @@ function CreateCabinForm({ cabinToEdit = {} }) {
           onSuccess: (data) => {
             // console.log(data)
             reset();
+            onCloseModal?.();
           },
         }
       );
@@ -49,6 +50,7 @@ function CreateCabinForm({ cabinToEdit = {} }) {
           onSuccess: (data) => {
             // console.log(data)
             reset();
+            onCloseModal?.();
           },
         }
       );
@@ -62,7 +64,10 @@ function CreateCabinForm({ cabinToEdit = {} }) {
   }
 
   return (
-    <Form onSubmit={handleSubmit(onSubmit, onError)}>
+    <Form
+      onSubmit={handleSubmit(onSubmit, onError)}
+      type={onCloseModal ? "modal" : "regular"}
+    >
       <FormRow label="Cabin name" error={errors?.name?.message}>
         {
           <Input
@@ -146,7 +151,11 @@ function CreateCabinForm({ cabinToEdit = {} }) {
 
       <FormRow>
         {/* type is an HTML attribute! */}
-        <Button variation="secondary" type="reset">
+        <Button
+          variation="secondary"
+          type="reset"
+          onClick={() => onCloseModal?.()}
+        >
           Cancel
         </Button>
         <Button disabled={isWorking}>

--- a/src/hooks/useOutsideClick.js
+++ b/src/hooks/useOutsideClick.js
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from "react";
+
+export function useOutsideClick(handler, listenCapturing = true) {
+  const ref = useRef();
+
+  // click outside window to close
+  useEffect(() => {
+    function handleClick(e) {
+      if (ref.current && !ref.current.contains(e.target)) {
+        console.log("Click outside");
+        handler();
+      }
+    }
+
+    document.addEventListener("click", handleClick, listenCapturing);
+
+    return () => {
+      document.removeEventListener("click", handleClick, listenCapturing);
+    };
+  }, [handler, listenCapturing]);
+  return ref;
+}

--- a/src/pages/Cabins.jsx
+++ b/src/pages/Cabins.jsx
@@ -1,12 +1,10 @@
 import Heading from "../ui/Heading";
 import Row from "../ui/Row";
-import Button from "../ui/Button";
 import CabinTable from "../features/cabins/CabinTable";
-import { useState } from "react";
-import CreateCabinForm from "../features/cabins/CreateCabinForm";
+import AddCabin from "../features/cabins/AddCabin";
 
 function Cabins() {
-  const [showForm, setShowForm] = useState(false);
+ 
 
   return (
     <>
@@ -17,10 +15,7 @@ function Cabins() {
 
       <Row>
         <CabinTable />
-        <Button onClick={() => setShowForm((show) => !show)}>
-          Add new cabin
-        </Button>
-        {showForm && <CreateCabinForm />}
+       <AddCabin />
       </Row>
     </>
   );

--- a/src/ui/ConfirmDelete.jsx
+++ b/src/ui/ConfirmDelete.jsx
@@ -20,7 +20,7 @@ const StyledConfirmDelete = styled.div`
   }
 `;
 
-function ConfirmDelete({ resourceName, onConfirm, disabled }) {
+function ConfirmDelete({ resourceName, onConfirm, disabled, onCloseModal }) {
   return (
     <StyledConfirmDelete>
       <Heading as="h3">Delete {resourceName}</Heading>
@@ -30,10 +30,14 @@ function ConfirmDelete({ resourceName, onConfirm, disabled }) {
       </p>
 
       <div>
-        <Button variation="secondary" disabled={disabled}>
+        <Button
+          variation="secondary"
+          disabled={disabled}
+          onClick={onCloseModal}
+        >
           Cancel
         </Button>
-        <Button variation="danger" disabled={disabled}>
+        <Button variation="danger" disabled={disabled} onClick={onConfirm}>
           Delete
         </Button>
       </div>

--- a/src/ui/Form.jsx
+++ b/src/ui/Form.jsx
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 
 const Form = styled.form`
   ${(props) =>
-    props.type !== "modal" &&
+    props.type === "regular" &&
     css`
       padding: 2.4rem 4rem;
 
@@ -21,5 +21,9 @@ const Form = styled.form`
   overflow: hidden;
   font-size: 1.4rem;
 `;
+
+Form.defaultProps = {
+  type: 'regular',
+}
 
 export default Form;

--- a/src/ui/Modal-v1.jsx
+++ b/src/ui/Modal-v1.jsx
@@ -1,10 +1,7 @@
-
 import styled from "styled-components";
 
 import { HiXMark } from "react-icons/hi2";
 import { createPortal } from "react-dom";
-import { cloneElement, createContext, useContext, useState } from "react";
-import { useOutsideClick } from "../hooks/useOutsideClick";
 
 const StyledModal = styled.div`
   position: fixed;
@@ -54,56 +51,20 @@ const Button = styled.button`
     color: var(--color-grey-500);
   }
 `;
-// 1) Create a new context
-const ModalContext = createContext();
 
-// 2) Create the parent component - that accepts children
-
-function Modal({ children }) {
-  const [openName, setOpenName] = useState("");
-  //close - set back to empty string
-  const close = () => setOpenName("");
-
-  //open just set OpenName - this will be cabin-form or whatever name is on the form
-  const open = setOpenName;
-
-  return (
-    <ModalContext.Provider value={{ openName, close, open }}>
-      {children}
-    </ModalContext.Provider>
-  );
-}
-
-function Open({ children, opens: opensWindowName }) {
-  const { open } = useContext(ModalContext);
-
-  return cloneElement(children, { onClick: () => open(opensWindowName) });
-}
-
-function Window({ children, name }) {
-  const { openName, close } = useContext(ModalContext);
-
-  const ref = useOutsideClick(close)
-
-  if (name !== openName) return null;
-
+function Modal({ children, onClose }) {
   return createPortal(
     <Overlay>
-      <StyledModal ref={ref}>
-        <Button onClick={close}>
+      <StyledModal>
+        <Button onClick={onClose}>
           <HiXMark />
         </Button>
-        <div>{cloneElement(children, { onCloseModal: close })}</div>
+        <div>{children}</div>
       </StyledModal>
     </Overlay>,
     //portal created, mocal will be created as a direct child  of document body, in DOM. To attach it to a element use - document.querySelector('')
     document.body
   );
 }
-
-// 3) Place these as properties on the Modal
-
-Modal.Open = Open;
-Modal.Window = Window;
 
 export default Modal;

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,5 +1,8 @@
 import styled from "styled-components";
 
+import { HiXMark } from "react-icons/hi2";
+import { createPortal } from "react-dom";
+
 const StyledModal = styled.div`
   position: fixed;
   top: 50%;
@@ -48,3 +51,20 @@ const Button = styled.button`
     color: var(--color-grey-500);
   }
 `;
+
+function Modal({ children, onClose }) {
+  return createPortal(
+    <Overlay>
+      <StyledModal>
+        <Button onClick={onClose}>
+          <HiXMark />
+        </Button>
+        <div>{children}</div>
+      </StyledModal>
+    </Overlay>,
+    //portal created, mocal will be created as a direct child  of document body, in DOM. To attach it to a element use - document.querySelector('')
+    document.body
+  );
+}
+
+export default Modal;


### PR DESCRIPTION
modal form added, using a reusable compound component, with Modal.Open and Modal.Window, can easily place any component inside this modal, and wrap the Modal.Open around any button.        

Here, Modal component is used to open the edit form, when the edit cabin is clicked, and another opens the confirm delete prop, when a user clicks delete.      

Also, used for the Add new Cabin button and form. 

This gives a reusable modal, that can be used easily anywhere.  